### PR TITLE
Inline favicon via data URI

### DIFF
--- a/gallery.html
+++ b/gallery.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Digital Gratitude List — Photo Explorer</title>
+  <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAZElEQVR42u3XwREAEBBD0XRgHNSnaf1QAXaMJUwOzv/dNhBiqjcfBHgKkEs1ve0Aa3gFAq+4FQHPuAUB7/gMgRPxEYIP4BXvIQQQQAAB+AC6BRTnmGKQUEwyilFKMcv1M/oa0AD36JLNg+KoVQAAAABJRU5ErkJggg==">
   <style>
     :root {
       color-scheme: dark;

--- a/index.html
+++ b/index.html
@@ -4,6 +4,7 @@
   <meta charset="utf-8">
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <title>Zack Moritz — Site v3</title>
+  <link rel="icon" type="image/png" href="data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAACAAAAAgCAYAAABzenr0AAAAZElEQVR42u3XwREAEBBD0XRgHNSnaf1QAXaMJUwOzv/dNhBiqjcfBHgKkEs1ve0Aa3gFAq+4FQHPuAUB7/gMgRPxEYIP4BXvIQQQQAAB+AC6BRTnmGKQUEwyilFKMcv1M/oa0AD36JLNg+KoVQAAAABJRU5ErkJggg==">
   <style>
     body { margin:0; font-family: system-ui, sans-serif; background:#0f1115; color:#e7ecf1; }
     .wrap { max-width:800px; margin:0 auto; padding:40px 20px; }


### PR DESCRIPTION
## Summary
- remove the binary favicon asset from version control
- inline an equivalent 32×32 PNG favicon via data URI in both index.html and gallery.html

## Testing
- not run (not applicable)


------
https://chatgpt.com/codex/tasks/task_e_68d59ea5e984832994b8e1e095215807